### PR TITLE
[OoT] Fix rendering when roomless objects are mixed with room-bound objects

### DIFF
--- a/oot.py
+++ b/oot.py
@@ -53,7 +53,7 @@ def get_oot_room_childrens(scene: bpy.types.Scene):
     for scene_obj in scene_objs:
         get_scene_children(scene_obj, scene_obj.name)
 
-    fake_room = RoomRenderInfo(render_state, None)
+    fake_room = RoomRenderInfo(render_state, "")
     for obj in bpy.data.objects:
         if obj.name not in oot_room_lookup:
             oot_room_lookup[obj.name] = fake_room
@@ -125,7 +125,9 @@ def draw_oot_scene(
         room_queue = layer_queue.get(layer)
         if room_queue is None:
             continue
-        for room, obj_queue in sorted(room_queue.items(), key=lambda item: item[0].name):  # sort by layer
+        # sort by room name, this doesn't correspond to something the fast64 exporter or the game rendering does
+        # but it at least helps make the behavior reproducible
+        for room, obj_queue in sorted(room_queue.items(), key=lambda item: item[0].name):
             render_state = room.render_state.copy()
             render_state.set_values_from_cache(layer_rendermodes.get(layer, layer_rendermodes["Opaque"]))
             for info in dict(sorted(obj_queue.items(), key=lambda item: item[0])):  # sort by obj name


### PR DESCRIPTION
How to reproduce the bug in main:
1) switch to OoT gamemode in fast64
2) create a scene (click "Add scene" button), this adds a mesh parented to a room
3) create a mesh without parenting it to any room
4) observe that nothing is rendered anymore and the following error is in stdout:
```
Traceback (most recent call last):
  File "/home/dragorn421/.config/blender/4.2/scripts/addons/f64render_gitlinked/renderer.py", line 314, in draw_scene
    draw_oot_scene(self, depsgraph, hidden_objs, space_view_3d, projection_matrix, view_matrix, always_set)
  File "/home/dragorn421/.config/blender/4.2/scripts/addons/f64render_gitlinked/oot.py", line 128, in draw_oot_scene
    for room, obj_queue in sorted(room_queue.items(), key=lambda item: item[0].name):  # sort by layer
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```