### PR TITLE
Fix `Fast64RenderEngine.__init__` not taking and passing args, kwargs to superclass

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -43,8 +43,8 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
     bl_label = "Fast64 Renderer"
     bl_use_preview = False
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         addon_set_fast64_path()
 
         self.shader = None


### PR DESCRIPTION
This bug was causing the render engine to not work in blender 4.4.3