### PR TITLE
Add DATA_PT_EEVEE_light to include_panels

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -383,7 +383,7 @@ def get_panels():
         "VIEWLAYER_PT_layer_passes",
     }
 
-    include_panels = {"EEVEE_MATERIAL_PT_context_material", "MATERIAL_PT_preview"}
+    include_panels = {"EEVEE_MATERIAL_PT_context_material", "MATERIAL_PT_preview", "DATA_PT_EEVEE_light"}
 
     panels = []
     for panel in bpy.types.Panel.__subclasses__():


### PR DESCRIPTION
it turns out this panel:

<img width="884" height="361" alt="image" src="https://github.com/user-attachments/assets/9c7c6c0b-92d8-4cb8-8ac6-086c9c023d7b" />

is eevee-specific so it is hidden by default for other renderers

But it's useful because it allows setting the light color which is used in at least oot and sm64

So this PR sets this panel to also show with the f64render renderer.

Note this causes a seemingly duplicate panel, as the other panel `DATA_PT_light` specific to non-EEVEE still shows

<img width="884" height="513" alt="image" src="https://github.com/user-attachments/assets/f76e8a6a-9e9b-4898-96eb-321a0d064e68" />

I could remove `DATA_PT_light` from the shown panels if we wanted but idk