### PR TITLE
Fix builtin shader_fallback name blender version check

### DIFF
--- a/renderer.py
+++ b/renderer.py
@@ -163,7 +163,7 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
 
         self.shader = gpu.shader.create_from_info(shader_info)
         self.shader_fallback = gpu.shader.from_builtin(
-            "3D_UNIFORM_COLOR" if bpy.app.version < (4, 1, 0) else "UNIFORM_COLOR"
+            "3D_UNIFORM_COLOR" if bpy.app.version < (3, 4, 0) else "UNIFORM_COLOR"
         )
         self.vbo_format = self.shader.format_calc()
 


### PR DESCRIPTION
For some reason the version check used < 4.1.0 when the change happened between 3.3 and 3.4
https://docs.blender.org/api/3.3/gpu.shader.html#built-in-shaders : 3D_UNIFORM_COLOR
https://docs.blender.org/api/3.4/gpu.shader.html#built-in-shaders : UNIFORM_COLOR