### PR TITLE
Update black-lint GHA

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -9,5 +9,5 @@ jobs:
     permissions: {} # Remove all permissions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: psf/black@23.12.1


### PR DESCRIPTION
sister PR to https://github.com/Fast-64/fast64/pull/682 , same reason