### PR TITLE
Do not create a bpy Image for missing textures

### DIFF
--- a/material/tile.py
+++ b/material/tile.py
@@ -4,6 +4,8 @@ import gpu
 from dataclasses import dataclass
 import numpy as np
 
+MISSING_TEXTURE_COLOR = (0, 0, 0, 1)
+
 TEX_FLAG_MONO = 1 << 0
 TEX_FLAG_4BIT = 1 << 1
 TEX_FLAG_3BIT = 1 << 2
@@ -27,7 +29,15 @@ def get_tile_conf(tex: "TextureProperty") -> F64Texture:
         if tex.tex_format == "IA4":
             flags |= TEX_FLAG_3BIT
     else:
-        buff = gpu.texture.from_image(bpy.data.images["f64render_missing_texture"])
+        buff = gpu.types.GPUTexture(
+            (1, 1),
+            format="RGBA8",
+            data=gpu.types.Buffer(
+                "FLOAT",
+                (1, 1, 4),
+                [[MISSING_TEXTURE_COLOR]],
+            ),
+        )
         flags |= TEX_FLAG_MONO
 
     conf = np.array(

--- a/renderer.py
+++ b/renderer.py
@@ -21,8 +21,6 @@ from .oot import draw_oot_scene
 # N64 is y-up, blender is z-up
 yup_to_zup = mathutils.Quaternion((1, 0, 0), math.radians(90.0)).to_matrix().to_4x4()
 
-MISSING_TEXTURE_COLOR = (0, 0, 0, 1)
-
 
 def cache_del_by_mesh(mesh_name):
     for key in list(F64_GLOBALS.meshCache.keys()):
@@ -93,10 +91,6 @@ class Fast64RenderEngine(bpy.types.RenderEngine):
         bpy.app.handlers.depsgraph_update_post.append(Fast64RenderEngine.mesh_change_listener)
         bpy.app.handlers.frame_change_post.append(Fast64RenderEngine.mesh_change_listener)
         bpy.app.handlers.load_pre.append(Fast64RenderEngine.on_file_load)
-
-        if "f64render_missing_texture" not in bpy.data.images:
-            # Create a 1x1 image
-            bpy.data.images.new("f64render_missing_texture", 1, 1).pixels = MISSING_TEXTURE_COLOR
 
         self.is_mesa_driver = check_if_under_mesa()
         if self.is_mesa_driver:


### PR DESCRIPTION
Currently f64render creates an image `f64render_missing_texture` that is used when a texture is not found

I found out you can create a GPUTexture out of pixel data directly without having to create a bpy `Image`

This way seems less fragile and less clutter in the blend.