### PR TITLE
Fix old Blender versions: `color_srgb` appeared in 3.4

### DIFF
--- a/mesh/mesh.py
+++ b/mesh/mesh.py
@@ -81,7 +81,7 @@ def mesh_to_buffers(mesh: bpy.types.Mesh) -> MeshBuffers:
     color_layer = getColorLayer(mesh, layer="Col")
     if color_layer is not None:
         colors_tmp = np.empty((len(color_layer), 4), dtype=np.float32)
-        if bpy.app.version > (3, 2, 0):
+        if bpy.app.version >= (3, 4, 0):
             color_layer.foreach_get("color_srgb", colors_tmp.ravel())
         else:  # vectorized linear -> sRGB conversion
             color_layer.foreach_get("color", colors_tmp.ravel())


### PR DESCRIPTION
Found while testing #30 

3.3, nothing: https://docs.blender.org/api/3.3/search.html?q=color_srgb&check_keywords=yes&area=default
3.4, found: https://docs.blender.org/api/3.4/search.html?q=color_srgb&check_keywords=yes&area=default